### PR TITLE
Ignore raids just like mirrors, and ignore thin/cache-pools

### DIFF
--- a/dump.php
+++ b/dump.php
@@ -41,6 +41,12 @@ foreach($data as $vgname => $value)
             $nparts = $datavalues['mirror_count'];
             $partkey = 'mirrors';
           }
+          if($datavalues['type'] == 'raid1')
+          {
+            $nparts = $datavalues['device_count'];
+            $partkey = 'raids';
+            $nparts = 0;
+          }
           if($datavalues['type'] == 'striped')
           {
             $nparts = $datavalues['stripe_count'];
@@ -55,6 +61,23 @@ foreach($data as $vgname => $value)
 
           $fpe    = $datavalues['start_extent'];
           $npe    = $datavalues['extent_count'] / $nparts_div;
+
+          if($datavalues['type'] == 'thin-pool')
+          {
+            $nparts = 0;
+          }
+          if($datavalues['type'] == 'thin')
+          {
+            $nparts = 0;
+          }
+          if($datavalues['type'] == 'cache')
+          {
+            $nparts = 0;
+          }
+          if($datavalues['type'] == 'cache-pool')
+          {
+            $nparts = 0;
+          }
 
           for($n=0; $n < $nparts; ++$n)
           {


### PR DESCRIPTION
I noticed a few php warnings about special lv types ... this should handle those just like it already did for mirror.